### PR TITLE
Amend Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,12 @@ endif
 
 # Use iconv when available
 # This is not cached across make invocations unfortunately
-HAVE_ICONV := $(shell echo "\#include <iconv.h>" | cpp >/dev/null 2>&1 && echo 1 || echo 0)
+HAVE_ICONV := $(shell echo "#include <iconv.h>" | cpp -xc >/dev/null 2>&1 && echo 1 || echo 0)
 ifeq ($(HAVE_ICONV),1)
     override CFLAGS+=-DHAVE_ICONV
 
     # Work around const warnings
-    ICONV_CONST := $(shell (echo "\#include <iconv.h>"; echo "size_t iconv(iconv_t,char **,size_t*,char **,size_t*);") | $(CC) -xc -S - -o- >/dev/null 2>&1 || echo const)
+    ICONV_CONST := $(shell (echo "#include <iconv.h>"; echo "size_t iconv(iconv_t,char **,size_t*,char **,size_t*);") | $(CC) -xc -S - -o- >/dev/null 2>&1 || echo const)
     override CFLAGS+=-DICONV_CONST="$(ICONV_CONST)"
 
     # Add -liconv where available/required like Mac OS X & CYGWIN for example

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ else
 endif
 
 # Use `make UNIVERSAL=1` to build a Mac OS X universal binary
-HAVE_MACOSX := $(shell gcc -xc -mmacosx-version-min -c - < /dev/null 2>/dev/null && echo 1 || echo 0)
+HAVE_MACOSX := $(shell $(CC) -xc -mmacosx-version-min -c - < /dev/null 2>/dev/null && echo 1 || echo 0)
 ifeq ($(UNIVERSAL),1)
 ifeq ($(HAVE_MACOSX),1)
     UNIVERSAL_BINARY := -mmacosx-version-min=10.4 -force_cpusubtype_ALL -arch x86_64 -arch i386 -arch ppc
@@ -27,7 +27,7 @@ endif
 
 # Use iconv when available
 # This is not cached across make invocations unfortunately
-HAVE_ICONV := $(shell echo "#include <iconv.h>" | cpp -xc >/dev/null 2>&1 && echo 1 || echo 0)
+HAVE_ICONV := $(shell echo "#include <iconv.h>" | $(CC) -xc -E - -o- >/dev/null 2>&1 && echo 1 || echo 0)
 ifeq ($(HAVE_ICONV),1)
     override CFLAGS+=-DHAVE_ICONV
 


### PR DESCRIPTION
With recent versions of GCC and GNU Make, the checks for `iconv` no longer correctly evaluate. The backslash before `#include` is the culprit which might have been necessary with ancient versions of GCC or GNU Make. Just for the record, I have GCC 10 as well as GCC 11 and GNU Make 4.3 on Debian GNU/Linux.
I have taken the chance to also replace the last occurrence of `gcc` and `cpp` in the Makefile by `$(CC)` and `$(CC) -E` respectively.